### PR TITLE
Optionally use environment PWD rather than Dir.pwd

### DIFF
--- a/lib/SassyExport.rb
+++ b/lib/SassyExport.rb
@@ -21,11 +21,12 @@ end
 # @param map [map] : map to convert to json
 # @param pretty [bool] : pretty print json
 # @param debug [bool] : print debug string with path
+# @param use_env [bool] : use ENV['PWD'] for current directory instead of Dir.pwd
 # ----------------------------------------------------------------------------------------------------
 # @return string | write json to path
 
 module Sass::Script::Functions
-    def SassyExport(path, map, pretty, debug)
+    def SassyExport(path, map, pretty, debug, use_env)
 
         def opts(value)
             value.options = options
@@ -106,17 +107,19 @@ module Sass::Script::Functions
         assert_type map, :Map, :map
         assert_type pretty, :Bool, :pretty
         assert_type debug, :Bool, :debug
+        assert_type use_env, :Bool, :use_env
 
         # parse to bool
         pretty = pretty.to_bool
         debug = debug.to_bool
+        use_env = use_env.to_bool
 
         # parse to string
         path = unquote(path).to_s
 
         # define root path up to current working directory
-        root = Dir.pwd
-
+        root = use_env ? ENV['PWD'] : Dir.pwd
+        
         # define dir path
         dir_path = root
         dir_path += path
@@ -169,5 +172,5 @@ module Sass::Script::Functions
         # return succcess string
         opts(Sass::Script::Value::String.new(debug_msg))
     end
-    declare :SassyExport, [:path, :map, :pretty, :debug]
+    declare :SassyExport, [:path, :map, :pretty, :debug, :use_env]
 end

--- a/stylesheets/_SassyExport.scss
+++ b/stylesheets/_SassyExport.scss
@@ -4,15 +4,16 @@
 // @param $map [map] : map to convert to json
 // @param $pretty [bool] : pretty print json
 // @param $debug [bool] : print debug string with path
+// @param use_env [bool] : use ENV['PWD'] for current directory instead of Dir.pwd
 // ----------------------------------------------------------------------------------------------------
 // @return $string | write to path
 
-@mixin SassyExport($path, $map, $pretty: false, $debug: false) {
+@mixin SassyExport($path, $map, $pretty: false, $debug: false, $use_env: false) {
     @at-root {
         @if $debug {
-            /*! #{SassyExport($path, $map, $pretty, $debug)} */
+            /*! #{SassyExport($path, $map, $pretty, $debug, $use_env)} */
         } @else {
-            %SassExport { /*! #{SassyExport($path, $map, $pretty, $debug)} */ }
+            %SassExport { /*! #{SassyExport($path, $map, $pretty, $debug, $use_env)} */ }
         }
     }
 }


### PR DESCRIPTION
When compiling Sass with grunt the extension is using the current working directory from where the grunttask was run rather than the directory the Sass lives in.  Normally, that's not a huge issue, but when trying to asychronously compile multiple projects using a single gruntfile then it's impossible to discern where the output is coming from without using different output files for each project.

Ex folder structure:
root\
|-- project_1\
|   |-- sass\
|       |-- something.sass
|   |-- config.rb
|-- project_2\
|   |-- sass\
|       |-- another_file.sass
|   |-- config.rb
|-- Gruntfile

```
Running the Grunt task with the current setup will dump the output files into root\ when it would make sense to keep them in the folder where the sass is compiled from.  The proposed changes would output the SassExport files into the root\project_1\ and root\project_2\ folders respectively.
```
